### PR TITLE
Add some stub manifests for the Argo bits

### DIFF
--- a/manifests/argo/MinIO notification.md
+++ b/manifests/argo/MinIO notification.md
@@ -1,0 +1,78 @@
+# Consumed notifications
+
+## Overall Argo Events event structure
+
+> Taken from [Argo Events docs](https://argoproj.github.io/argo-events/setup/minio/#event-structure)
+
+```json
+{
+  "context": {
+    "type": "type_of_gateway",
+    "specVersion": "cloud_events_version",
+    "source": "name_of_the_gateway",
+    "eventID": "unique_event_id",
+    "time": "event_time",
+    "dataContentType": "type_of_data",
+    "subject": "name_of_the_event_within_event_source"
+  },
+  "data": {
+    "notification": [
+      //   List of MinIO notifications
+    ]
+  }
+}
+```
+
+## Example of a MinIO notification
+
+> Taken from [MinIO docs](https://github.com/minio/minio/blob/master/docs/bucket/notifications/README.md#step-4-test-on-kafka)
+
+```json
+{
+  "eventVersion": "2.0",
+  "eventSource": "minio:s3",
+  "awsRegion": "",
+  "eventTime": "2019-09-10T17:41:54Z",
+  "eventName": "s3:ObjectCreated:Put",
+  "userIdentity": {
+    "principalId": "AKIAIOSFODNN7EXAMPLE"
+  },
+  "requestParameters": {
+    "accessKey": "AKIAIOSFODNN7EXAMPLE",
+    "region": "",
+    "sourceIPAddress": "192.168.56.192"
+  },
+  "responseElements": {
+    "x-amz-request-id": "15C3249451E12784",
+    "x-minio-deployment-id": "751a8ba6-acb2-42f6-a297-4cdf1cf1fa4f",
+    "x-minio-origin-endpoint": "http://192.168.97.83:9000"
+  },
+  "s3": {
+    "s3SchemaVersion": "1.0",
+    "configurationId": "Config",
+    "bucket": {
+      "name": "images",
+      "ownerIdentity": {
+        "principalId": "AKIAIOSFODNN7EXAMPLE"
+      },
+      "arn": "arn:aws:s3:::images"
+    },
+    "object": {
+      "key": "myphoto.jpg",
+      "size": 6474,
+      "eTag": "430f89010c77aa34fc8760696da62d08-1",
+      "contentType": "image/jpeg",
+      "userMetadata": {
+        "content-type": "image/jpeg"
+      },
+      "versionId": "1",
+      "sequencer": "15C32494527B46C5"
+    }
+  },
+  "source": {
+    "host": "192.168.56.192",
+    "port": "",
+    "userAgent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:69.0) Gecko/20100101 Firefox/69.0"
+  }
+}
+```

--- a/manifests/argo/argo-events-minio-es.yaml
+++ b/manifests/argo/argo-events-minio-es.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: EventSource
+metadata:
+  name: minio-event-source
+spec:
+  type: minio
+  minio:
+    new-data-notification:
+      bucket:
+        name: BUCKET_NAME
+      endpoint: MINIO_SERVER_HOST
+      events:
+        - s3:ObjectCreated:Put
+      insecure: true
+      accessKey:
+        key: accesskey
+        name: artifacts-minio
+      secretKey:
+        key: secretkey
+        name: artifacts-minio

--- a/manifests/argo/argo-events-minio-gw.yaml
+++ b/manifests/argo/argo-events-minio-gw.yaml
@@ -1,0 +1,13 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Gateway
+metadata:
+  name: gateway
+spec:
+  type: minio
+  eventSourceRef:
+    name: event-source
+  template:
+    serviceAccountName: argo-events-sa
+  subscribers:
+    http:
+      - "http://sensor.NAMESPACE.svc:9300/"

--- a/manifests/argo/argo-events-sn.yaml
+++ b/manifests/argo/argo-events-sn.yaml
@@ -1,0 +1,64 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: sensor
+spec:
+  template:
+    serviceAccountName: argo-events-sa
+  subscription:
+    http:
+      port: 9300
+  dependencies:
+    - name: bucket-notification
+      gatewayName: gateway
+      eventName: new-data-notification
+  triggers:
+    - template:
+        name: argo-workflow
+        k8s:
+          group: argoproj.io
+          version: v1alpha1
+          resource: workflows
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: odh-ml-pipelines-
+              spec:
+                entrypoint: entrypoint
+                arguments:
+                  parameters:
+                    - name: message
+                templates:
+                  - name: entrypoint
+                    inputs:
+                      parameters:
+                        - name: key
+                    outputs:
+                      artifacts:
+                        - name: output
+                          path: "/tmp/output.txt"
+                          archive:
+                            none: {}
+                          s3:
+                            endpoint: s3.upshift.redhat.com:443
+                            bucket: BUCKET_NAME
+                            key: "processe_data/{{inputs.parameters.key}} "
+                            accessKeySecret:
+                              key: accesskey
+                              name: CEPH_SECRET
+                            secretKeySecret:
+                              key: secretkey
+                              name: CEPH_SECRET
+                    container:
+                      image: docker/whalesay:latest
+                      command: [sh, -c]
+                      args:
+                        - "cowsay {{inputs.parameters.key}} | tee /tmp/output.txt"
+          parameters:
+            - src:
+                dependencyName: bucket-notification
+                dataKey: notification.0.s3.object.key
+              dest: spec.arguments.parameters.0.value

--- a/manifests/argo/kustomization.yaml
+++ b/manifests/argo/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/component: argo
+
+resources:
+  - ./argo-events-minio-es.yaml
+  - ./argo-events-minio-gw.yaml
+  - ./argo-events-sn.yaml

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+commonLabels:
+  app.kubernetes.io/name: odh-ml-pipelines
+
+resources:
+  - ./argo


### PR DESCRIPTION
Add manifests for:

- [x] `EventSource` - MinIO notification definition
- [x] `Gateway` - Listening for the notifications from ^
- [x] `Sensor` - Trigger a workflow consuming the object `key` and uploading output to S3.
