### PR TITLE
Partial fix for argo workflow execution + map to MinIO

### DIFF
--- a/manifests/argo/argo-events-minio-es.yaml
+++ b/manifests/argo/argo-events-minio-es.yaml
@@ -7,8 +7,8 @@ spec:
   minio:
     new-data-notification:
       bucket:
-        name: BUCKET_NAME
-      endpoint: MINIO_SERVER_HOST
+        name: input
+      endpoint: minio-internal-service.devconf.svc:9000
       events:
         - s3:ObjectCreated:Put
       insecure: true

--- a/manifests/argo/argo-events-minio-gw.yaml
+++ b/manifests/argo/argo-events-minio-gw.yaml
@@ -1,13 +1,13 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Gateway
 metadata:
-  name: gateway
+  name: minio
 spec:
   type: minio
   eventSourceRef:
-    name: event-source
+    name: minio-event-source
   template:
     serviceAccountName: argo-events-sa
   subscribers:
     http:
-      - "http://sensor.NAMESPACE.svc:9300/"
+      - "http://minio-sensor.devconf.svc:9300"

--- a/manifests/argo/argo-events-sn.yaml
+++ b/manifests/argo/argo-events-sn.yaml
@@ -1,7 +1,7 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Sensor
 metadata:
-  name: sensor
+  name: minio
 spec:
   template:
     serviceAccountName: argo-events-sa
@@ -10,7 +10,7 @@ spec:
       port: 9300
   dependencies:
     - name: bucket-notification
-      gatewayName: gateway
+      gatewayName: minio
       eventName: new-data-notification
   triggers:
     - template:
@@ -28,37 +28,17 @@ spec:
                 generateName: odh-ml-pipelines-
               spec:
                 entrypoint: entrypoint
-                arguments:
-                  parameters:
-                    - name: message
                 templates:
                   - name: entrypoint
                     inputs:
                       parameters:
                         - name: key
-                    outputs:
-                      artifacts:
-                        - name: output
-                          path: "/tmp/output.txt"
-                          archive:
-                            none: {}
-                          s3:
-                            endpoint: s3.upshift.redhat.com:443
-                            bucket: BUCKET_NAME
-                            key: "processe_data/{{inputs.parameters.key}} "
-                            accessKeySecret:
-                              key: accesskey
-                              name: CEPH_SECRET
-                            secretKeySecret:
-                              key: secretkey
-                              name: CEPH_SECRET
                     container:
                       image: docker/whalesay:latest
-                      command: [sh, -c]
-                      args:
-                        - "cowsay {{inputs.parameters.key}} | tee /tmp/output.txt"
+                      command: [cowsay]
+                      args: ["{{inputs.parameters.key}}"]
           parameters:
             - src:
                 dependencyName: bucket-notification
                 dataKey: notification.0.s3.object.key
-              dest: spec.arguments.parameters.0.value
+              dest: spec.templates.0.inputs.parameters.0.value

--- a/manifests/argo/kustomization.yaml
+++ b/manifests/argo/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./argo-events-minio-es.yaml
   - ./argo-events-minio-gw.yaml
   - ./argo-events-sn.yaml
+  - ./workflow-controller-configmap.yaml


### PR DESCRIPTION
- Replace the stub values with actual MinIO links etc.
- Update workflow controller configmap to use `kubelet` so it can execute pods. Probably some roles are still missing.
